### PR TITLE
Close the repository quality standard gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,17 @@ jobs:
           node-version-file: .nvmrc
       - name: Verify publishable contents
         run: npm pack --dry-run
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      # Thresholds run on the .nvmrc runtime only: the built-in coverage
+      # threshold flags require Node 22, while the suite itself still has to
+      # pass on the supported Node 20 floor.
+      - name: Enforce coverage thresholds
+        run: npm run test:coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish, for example v0.1.0
+        required: true
+
+# Least privilege by default; only the publishing job is granted write access.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.identity.outputs.tag }}
+      version: ${{ steps.identity.outputs.version }}
+      tarball: ${{ steps.pack.outputs.tarball }}
+      prerelease: ${{ steps.identity.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve release identity from the tag
+        id: identity
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          prerelease=false
+          case "$version" in 0.*|*-*) prerelease=true ;; esac
+          {
+            echo "tag=$TAG"
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify the tag, package version, and changelog agree
+        run: node scripts/release.mjs verify --tag "${{ steps.identity.outputs.tag }}"
+
+      - run: npm run lint
+
+      - run: npm test
+
+      - name: Build the release tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          tarball="$(npm pack --silent)"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test the built artifact in a clean environment
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          PROJECT_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          consumer="$(mktemp -d)"
+          tarball="$PWD/$TARBALL"
+          cd "$consumer"
+          npm init -y --silent > /dev/null
+          npm install --silent --ignore-scripts "$tarball"
+          bin="$consumer/node_modules/.bin/agent-trestle"
+          test "$("$bin" --version)" = "$VERSION"
+          "$bin" --help | grep -Fq "$PROJECT_URL"
+          "$bin" --help | grep -Fq "$PROJECT_URL/issues"
+          "$bin" --version --json | grep -Fq "\"version\":\"$VERSION\""
+
+      - name: Generate release notes from the changelog
+        run: |
+          node scripts/release.mjs notes \
+            --tag "${{ steps.identity.outputs.tag }}" \
+            --out release-notes.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ steps.identity.outputs.version }}
+          path: |
+            ${{ steps.pack.outputs.tarball }}
+            release-notes.md
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    name: Publish GitHub release
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-${{ needs.verify.outputs.version }}
+
+      - name: Create or update the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          TITLE: Agent Trestle ${{ needs.verify.outputs.version }}
+          TARBALL: ${{ needs.verify.outputs.tarball }}
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          flags=()
+          if [ "$PRERELEASE" = "true" ]; then flags+=(--prerelease); fi
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TITLE" --notes-file release-notes.md "${flags[@]}"
+            gh release upload "$TAG" "$TARBALL" --clobber
+          else
+            gh release create "$TAG" "$TARBALL" \
+              --title "$TITLE" --notes-file release-notes.md "${flags[@]}"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+### Added
+
+- Release automation: pushing a `vX.Y.Z` tag runs `.github/workflows/release.yml`,
+  which checks that the tag, `package.json` version, and changelog section
+  agree, runs lint and tests, packs the tarball, smoke-tests it in a clean
+  install, and publishes a GitHub release carrying the changelog notes and the
+  tarball as an asset. The workflow can also be dispatched for an existing tag.
+- `scripts/release.mjs`, a dependency-free `verify` and `notes` helper used by
+  the release workflow, covered by `test/unit/release-metadata.test.mjs`.
+- A `Coverage` CI job and `npm run test:coverage`, enforcing line, branch, and
+  function thresholds through the Node built-in coverage reporter. The job
+  closes a gap where `Coverage` was a required status check that no workflow
+  produced, which left every pull request waiting forever.
+
+### Changed
+
+- `--help` now states the version and links the repository and issue tracker,
+  and `--version --json` additionally reports `repository`, `bugs`, and
+  `license`. Plain `--version` still prints only the version string.
+- `SECURITY.md` now documents supported versions, the private advisory
+  reporting path, response targets, reporting scope, and disclosure
+  expectations, replacing the placeholder that pointed at a channel to be
+  configured "after publication".
+
 ## [0.1.0] — 2026-08-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,12 @@ There is no install step for dependencies, because there are none.
 | `npm test` | Full suite via the Node built-in test runner |
 | `npm run test:unit` | Unit tests only |
 | `npm run test:integration` | Integration tests only |
+| `npm run test:coverage` | Full suite plus coverage thresholds (needs Node 22) |
 | `npm run check` | Lint + tests + packaging verification |
 
 Run `npm run check` before pushing. CI runs the same commands on Node 20 and 22
-across Linux and macOS.
+across Linux and macOS, and enforces coverage thresholds in a separate
+`Coverage` job on the `.nvmrc` runtime.
 
 ## The zero-dependency rule
 
@@ -109,6 +111,27 @@ For pull requests:
 - add a `CHANGELOG.md` entry under `Unreleased`;
 - update `docs/` when you change the command surface, configuration schema, or
   security model.
+
+## Releasing
+
+Releases are cut from tags and published by
+[`.github/workflows/release.yml`](.github/workflows/release.yml); nothing is
+uploaded by hand.
+
+1. Move the `Unreleased` changelog entries under a `## [X.Y.Z] — YYYY-MM-DD`
+   heading and set the same version in `package.json`.
+2. Merge that change, then tag the merge commit `vX.Y.Z` and push the tag.
+3. The workflow verifies that the tag, `package.json` version, and changelog
+   section agree (`node scripts/release.mjs verify --tag vX.Y.Z`), runs lint
+   and the full suite, packs the tarball, installs it into a clean consumer,
+   asserts that the installed CLI reports the tagged version and links back to
+   this repository, and publishes the GitHub release with the changelog
+   section as notes and the tarball attached.
+
+A mismatch between tag, manifest, and changelog fails the release before any
+artifact is published. Versions below `1.0.0` and any tag with a pre-release
+suffix are marked as pre-releases. Existing tags can be re-published through
+the workflow's manual dispatch input.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ The executable is intentionally named only `agent-trestle`, never `trestle`, to
 avoid colliding with existing npm packages that already install a `trestle`
 binary.
 
+Tagged releases also attach a packed tarball, so a release can be installed
+without a clone:
+
+```bash
+npm install -g https://github.com/trsdn/agent-trestle/releases/download/vX.Y.Z/agent-trestle-X.Y.Z.tgz
+```
+
+Every release tarball is built, smoke-tested in a clean install, and published
+by [the release workflow](.github/workflows/release.yml); `agent-trestle
+--version` reports the version that was tagged.
+
 ## Quickstart
 
 ```bash
@@ -164,6 +175,7 @@ Read [SECURITY.md](SECURITY.md) for the reporting process and
 ```bash
 npm run lint      # dependency-free syntax, JSON, and whitespace checks
 npm test          # full Node built-in test runner suite
+npm run test:coverage  # full suite plus coverage thresholds (Node 22)
 npm run check     # lint + test + packaging verification
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Security
+# Security Policy
 
 Agent Trestle launches local AI agents that may read or modify repositories.
 The default policy is least privilege:
@@ -11,5 +11,63 @@ The default policy is least privilege:
 - the dashboard binds only to `127.0.0.1`;
 - state and audit paths are constrained to configured project roots.
 
-Do not report vulnerabilities through a public issue. Use the private security
-reporting channel configured on the repository after publication.
+The full threat model and containment guarantees are documented in
+[docs/security-model.md](docs/security-model.md).
+
+## Supported versions
+
+The project is pre-release and fixes land on the newest version only. There
+are no backports to earlier tags.
+
+| Version | Supported |
+| --- | --- |
+| Latest `0.1.x` release and `main` | Yes |
+| Any earlier tag | No — upgrade first |
+
+## Reporting a vulnerability
+
+Report privately through GitHub Security Advisories:
+
+<https://github.com/trsdn/agent-trestle/security/advisories/new>
+
+The same form is reachable from the repository's **Security** tab via **Report
+a vulnerability**. Private vulnerability reporting is enabled, so the report
+stays visible only to you and the maintainer.
+
+**Do not** open a public issue, pull request, or discussion for a suspected
+vulnerability, and please do not disclose details publicly until a fix or a
+documented mitigation is available.
+
+Include, where you can:
+
+- the affected release or commit, plus your OS and Node.js version;
+- the relevant `.trestle/config.json` settings, with secrets and private paths
+  redacted;
+- reproduction steps or a proof of concept;
+- the impact you expect, such as containment escape, audit tampering, review
+  bypass, or credential exposure.
+
+## What to expect
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement of the report | 3 working days |
+| Initial assessment and severity | 10 working days |
+| Fix or documented mitigation for a confirmed high-severity issue | 30 days |
+| Advisory, release, and changelog entry | with the fix |
+
+Reporters are credited in the advisory unless they ask not to be. This is a
+volunteer-maintained project, so these are targets rather than guarantees; if a
+report goes unanswered past these windows, please ping the advisory thread.
+
+## Scope
+
+In scope: containment escapes from configured project roots, review-gate or
+audit-integrity bypasses, dashboard exposure beyond `127.0.0.1`, privilege
+escalation past the documented permission defaults, and credential or state
+leakage in logs and audit records.
+
+Out of scope: vulnerabilities in Node.js, Git, or the GitHub Copilot CLI
+themselves — report those to their maintainers — and behaviour that follows
+directly from an operator deliberately enabling a documented opt-in such as
+`permissions.allowAllTools` or `permissions.autoMerge`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,8 +21,8 @@ are no backports to earlier tags.
 
 | Version | Supported |
 | --- | --- |
-| Latest `0.1.x` release and `main` | Yes |
-| Any earlier tag | No — upgrade first |
+| Latest release and `main` | Yes |
+| Any earlier release | No — upgrade first |
 
 ## Reporting a vulnerability
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test": "node --test",
     "test:unit": "node --test test/unit/*.test.mjs",
     "test:integration": "node --test test/integration/*.test.mjs",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='scripts/**' --test-coverage-lines=88 --test-coverage-branches=78 --test-coverage-functions=86",
     "check": "npm run lint && npm test && npm pack --dry-run"
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Dependency-free release metadata checks.
+//
+// A published artifact must be traceable back to the tag that produced it, so
+// the release workflow runs both subcommands before anything is uploaded:
+//
+//   verify --tag vX.Y.Z            fail unless the tag, `package.json`
+//                                  version, and changelog section agree
+//   notes --tag vX.Y.Z [--out F]   emit the changelog section for the tag
+//
+// Usage: node scripts/release.mjs <verify|notes> --tag <tag> [--out <file>]
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+const TAG_PATTERN =
+  /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/** Strip the release tag prefix, rejecting anything that is not `vX.Y.Z`. */
+export function versionFromTag(tag) {
+  if (typeof tag !== 'string' || !TAG_PATTERN.test(tag)) {
+    throw new Error(`Tag "${tag}" is not a v-prefixed semantic version such as v1.2.3`);
+  }
+  return tag.slice(1);
+}
+
+/** Return the changelog body documenting one version, without its heading. */
+export function extractReleaseNotes(changelog, version) {
+  const escaped = version.replace(/[.+]/g, '\\$&');
+  const heading = new RegExp(`^## \\[?${escaped}\\]?(?![0-9A-Za-z.+-])`);
+  const lines = String(changelog).split('\n');
+  const start = lines.findIndex((line) => heading.test(line));
+  if (start === -1) {
+    throw new Error(`CHANGELOG.md documents no "## [${version}]" section`);
+  }
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith('## '));
+  const body = (end === -1 ? rest : rest.slice(0, end)).join('\n').trim();
+  if (body === '') {
+    throw new Error(`The "## [${version}]" changelog section is empty`);
+  }
+  return body;
+}
+
+/** Parse the flag pairs this script accepts, rejecting anything unexpected. */
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const options = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const flag = rest[index];
+    if (flag !== '--tag' && flag !== '--out') {
+      throw new Error(`Unknown argument "${flag}"`);
+    }
+    const value = rest[index + 1];
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    options[flag.slice(2)] = value;
+    index += 1;
+  }
+  return { command, options };
+}
+
+async function main(argv) {
+  const { command, options } = parseArgs(argv);
+  if (command !== 'verify' && command !== 'notes') {
+    throw new Error('Usage: node scripts/release.mjs <verify|notes> --tag <tag> [--out <file>]');
+  }
+
+  const version = versionFromTag(options.tag);
+  const pkg = JSON.parse(await readFile(resolve(ROOT, 'package.json'), 'utf8'));
+  if (pkg.version !== version) {
+    throw new Error(`Tag ${options.tag} disagrees with package.json version ${pkg.version}`);
+  }
+  const notes = extractReleaseNotes(await readFile(resolve(ROOT, 'CHANGELOG.md'), 'utf8'), version);
+
+  if (command === 'notes') {
+    if (options.out) await writeFile(resolve(process.cwd(), options.out), `${notes}\n`, 'utf8');
+    else process.stdout.write(`${notes}\n`);
+    return;
+  }
+  process.stdout.write(
+    `${pkg.name} ${version} matches ${options.tag} and its CHANGELOG.md section\n`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`release: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/cli/main.mjs
+++ b/src/cli/main.mjs
@@ -324,7 +324,28 @@ function writeResult(io, value, json) {
   else io.stdout.write(`${JSON.stringify(serializable(value), null, 2)}\n`);
 }
 
-function usage() {
+/**
+ * Product identity read from the packaged manifest.
+ *
+ * The manifest is the single hand-maintained source, and the release workflow
+ * refuses to publish when it disagrees with the tag, so `--version` and
+ * `--help` cannot drift away from the artifact a user installed.
+ */
+async function packageIdentity() {
+  const pkg = JSON.parse(await readFile(path.resolve(PACKAGE_ROOT, "package.json"), "utf8"));
+  const repository = String(pkg.repository?.url ?? "")
+    .replace(/^git\+/, "")
+    .replace(/\.git$/, "");
+  return {
+    name: pkg.name,
+    version: pkg.version,
+    repository,
+    bugs: pkg.bugs?.url ?? `${repository}/issues`,
+    license: pkg.license,
+  };
+}
+
+function usage(identity) {
   return `Usage: agent-trestle <command> [options]
 
 Commands:
@@ -348,7 +369,11 @@ Global options:
   --root <path> Project root (default: current directory)
   --json        Emit machine-readable output where the command terminates
   --help        Show this help
-  --version     Show package version`;
+  --version     Show package version
+
+${identity.name} ${identity.version} (${identity.license})
+Project:      ${identity.repository}
+Report bugs:  ${identity.bugs}`;
 }
 
 async function validateProject(projectRoot) {
@@ -648,12 +673,12 @@ export async function runCli(argv, io = {}) {
   const { positionals, options } = parseArgs(argv);
   const json = options.json === true;
   if (options.version === true) {
-    const pkg = JSON.parse(await readFile(path.resolve(PACKAGE_ROOT, "package.json"), "utf8"));
-    writeResult(streams, json ? { name: pkg.name, version: pkg.version } : pkg.version, json);
+    const identity = await packageIdentity();
+    writeResult(streams, json ? identity : identity.version, json);
     return EXIT_CODES.SUCCESS;
   }
   if (options.help === true || positionals.length === 0) {
-    writeResult(streams, usage(), false);
+    writeResult(streams, usage(await packageIdentity()), false);
     return EXIT_CODES.SUCCESS;
   }
   const command = positionals[0];

--- a/test/integration/cli-contract.test.mjs
+++ b/test/integration/cli-contract.test.mjs
@@ -44,6 +44,31 @@ test("CLI identifies only the collision-resistant agent-trestle command", async 
   });
 });
 
+test("CLI reports its own version and links back to its source", async () => {
+  const pkg = JSON.parse(await readFile(path.resolve("package.json"), "utf8"));
+  const repository = pkg.repository.url.replace(/^git\+/, "").replace(/\.git$/, "");
+
+  const help = capture();
+  assert.equal(await runCli(["--help"], help.io), EXIT_CODES.SUCCESS);
+  assert.ok(help.stdout().includes(pkg.version), "help states the version");
+  assert.ok(help.stdout().includes(repository), "help links the repository");
+  assert.ok(help.stdout().includes(pkg.bugs.url), "help links the issue tracker");
+
+  const plain = capture();
+  assert.equal(await runCli(["--version"], plain.io), EXIT_CODES.SUCCESS);
+  assert.equal(plain.stdout().trim(), pkg.version);
+
+  const structured = capture();
+  assert.equal(await runCli(["--version", "--json"], structured.io), EXIT_CODES.SUCCESS);
+  assert.deepEqual(JSON.parse(structured.stdout()), {
+    name: pkg.name,
+    version: pkg.version,
+    repository,
+    bugs: pkg.bugs.url,
+    license: pkg.license,
+  });
+});
+
 test("init, validate, and resolve form a working least-privilege flow", async () => {
   await rm(fixtureRoot, { recursive: true, force: true });
   await mkdir(fixtureRoot, { recursive: true });

--- a/test/integration/package-install.test.mjs
+++ b/test/integration/package-install.test.mjs
@@ -40,6 +40,17 @@ test("npm pack installs a clean CLI with public exports and bundled templates", 
     process.platform === "win32" ? "agent-trestle.cmd" : "agent-trestle",
   );
   assert.equal(run(bin, ["--version"], { cwd: installRoot }).trim(), sourcePackage.version);
+  const installedHelp = run(bin, ["--help"], { cwd: installRoot });
+  const repository = sourcePackage.repository.url.replace(/^git\+/, "").replace(/\.git$/, "");
+  assert.ok(installedHelp.includes(repository), "installed help links the repository");
+  assert.ok(installedHelp.includes(sourcePackage.bugs.url), "installed help links the tracker");
+  assert.deepEqual(JSON.parse(run(bin, ["--version", "--json"], { cwd: installRoot })), {
+    name: sourcePackage.name,
+    version: sourcePackage.version,
+    repository,
+    bugs: sourcePackage.bugs.url,
+    license: sourcePackage.license,
+  });
   await assert.rejects(
     readFile(path.join(binDirectory, process.platform === "win32" ? "trestle.cmd" : "trestle")),
     (error) => error.code === "ENOENT",

--- a/test/unit/release-metadata.test.mjs
+++ b/test/unit/release-metadata.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { extractReleaseNotes, versionFromTag } from "../../scripts/release.mjs";
+
+const changelog = [
+  "# Changelog",
+  "",
+  "## [Unreleased]",
+  "",
+  "## [1.2.0] — 2026-01-02",
+  "",
+  "### Added",
+  "",
+  "- A documented change.",
+  "",
+  "## [1.2.0-rc.1] — 2026-01-01",
+  "",
+  "- A candidate change.",
+  "",
+].join("\n");
+
+test("release tags are accepted only as v-prefixed semantic versions", () => {
+  assert.equal(versionFromTag("v1.2.3"), "1.2.3");
+  assert.equal(versionFromTag("v1.2.3-rc.1"), "1.2.3-rc.1");
+  for (const rejected of ["1.2.3", "v1.2", "v1.2.3.4", "release-1.2.3", "v01.2.3", "", undefined]) {
+    assert.throws(() => versionFromTag(rejected), /not a v-prefixed semantic version/);
+  }
+});
+
+test("release notes come from the changelog section that documents the version", () => {
+  assert.equal(extractReleaseNotes(changelog, "1.2.0"), "### Added\n\n- A documented change.");
+  assert.equal(extractReleaseNotes(changelog, "1.2.0-rc.1"), "- A candidate change.");
+  assert.throws(() => extractReleaseNotes(changelog, "9.9.9"), /documents no "## \[9\.9\.9\]"/);
+  assert.throws(() => extractReleaseNotes(changelog, "Unreleased"), /section is empty/);
+});
+
+test("the released package version keeps a documented changelog section", async () => {
+  const root = path.resolve(".");
+  const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const notes = extractReleaseNotes(await readFile(path.join(root, "CHANGELOG.md"), "utf8"), pkg.version);
+  assert.ok(notes.length > 0, `CHANGELOG.md must document ${pkg.version}`);
+});


### PR DESCRIPTION
## Summary

Closes every gap found when auditing this repository against
[`trsdn/.github` → `docs/repository-quality-standard.md`](https://github.com/trsdn/.github/blob/main/docs/repository-quality-standard.md)
(v1.1), for the Baseline, Public, Software, Package, and Product Identity
profiles.

| Criterion | Gap | Fix |
| --- | --- | --- |
| B06 / S09 | `Coverage` was a required status check on `main` that **no workflow produced**, so every pull request waited forever on a check that could never report. The standard states: *"Never require a check that does not exist."* | A real `Coverage` job plus `npm run test:coverage`, enforcing line/branch/function thresholds via the Node built-in coverage reporter (thresholds 88/78/86 against a measured 91.2/82.6/90.5) |
| R03 / R04 / R05 | Tag `v0.1.0` existed with no release, no assets, and no release automation | `.github/workflows/release.yml`: verify tag ↔ `package.json` ↔ changelog, lint, test, pack, clean-install smoke test, publish |
| R06 / B08 | Release notes lived only in `CHANGELOG.md` | The workflow extracts the changelog section and publishes it as the release body |
| P03 | `SECURITY.md` pointed at a channel "configured … after publication" and named no supported versions or response expectations | Rewritten: supported versions, advisory URL, what to include, response targets, disclosure rules, scope |
| I04 / I06 | Neither `--version` nor `--help` linked the repository or issue tracker; version identity was hand-maintained only | `--help` states the version and links project + issues; `--version --json` reports `repository`, `bugs`, `license`; the release workflow fails when the manifest disagrees with the tag |

`v0.1.0` can be published retroactively with the workflow's manual dispatch
input once this merges.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Internal / refactor

## Checklist

- [x] `npm run check` passes locally (lint, tests, packaging)
- [x] New or changed behaviour is covered by tests
- [x] Least-privilege defaults are preserved (no new unrestricted tools, paths,
      URLs, non-interactive execution, or automatic merge enabled by default)
- [x] No source was copied from a tool whose licensing or provenance is
      uncleared; `THIRD_PARTY_NOTICES.md` is updated if anything was vendored
- [x] Documentation under `docs/` is updated if the command surface,
      configuration schema, or security model changed
- [x] `CHANGELOG.md` has an entry under `Unreleased`

## Security impact

No change to the threat model, containment guarantees, permission defaults, or
audit integrity.

- `SECURITY.md` documents the already-enabled private advisory path; it does
  not change any runtime behaviour.
- `release.yml` runs with `contents: read`; only the publishing job is granted
  `contents: write`, and it touches nothing but the GitHub release.
- The CLI identity change reads the packaged manifest on the `--help` and
  `--version` paths only and emits no configuration, path, or credential data.
