### PR TITLE
chore(release): Agent Trestle 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-08-24
+
 ### Added
 
 - Release automation: pushing a `vX.Y.Z` tag runs `.github/workflows/release.yml`,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ no npm dependency tree — only Node.js built-ins plus the `git` and Copilot CLI
 executables you already have installed.
 
 > [!NOTE]
-> **Project status: pre-release (`0.1.0`).** The command surface is
+> **Project status: pre-release (`0.2.0`).** The command surface is
 > functional but not yet API-stable. `run` and CLI-driven review merge are
 > deliberately unimplemented and exit with `NOT_SUPPORTED`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-trestle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local-first orchestration for GitHub Copilot CLI agents.",
   "type": "module",
   "author": "trsdn",


### PR DESCRIPTION
## Summary

Prepares the first release published by the new automation (#26): closes the
`Unreleased` changelog section as `0.2.0`, sets the manifest version, and
updates the status note in the README.

Once merged, pushing the `v0.2.0` tag runs
[`release.yml`](.github/workflows/release.yml), which verifies that the tag,
`package.json`, and changelog agree, packs the tarball, smoke-tests it in a
clean install, and publishes the GitHub release with the changelog section as
notes and the tarball as an asset.

Minor rather than patch: `--help` and `--version --json` gained user-visible
output in #26.

## Related issues

Follows #26.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Internal / refactor

## Checklist

- [x] `npm run check` passes locally (lint, tests, packaging)
- [x] New or changed behaviour is covered by tests
- [x] Least-privilege defaults are preserved (no new unrestricted tools, paths,
      URLs, non-interactive execution, or automatic merge enabled by default)
- [x] No source was copied from a tool whose licensing or provenance is
      uncleared; `THIRD_PARTY_NOTICES.md` is updated if anything was vendored
- [x] Documentation under `docs/` is updated if the command surface,
      configuration schema, or security model changed
- [x] `CHANGELOG.md` has an entry under `Unreleased`

## Security impact

None. Version metadata only.
