### PR TITLE
test: make the flaky symlink state-root test name its own failure

### DIFF
--- a/test/unit/state-store.test.mjs
+++ b/test/unit/state-store.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { hostname } from 'node:os';
-import { mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { after, beforeEach, test } from 'node:test';
 import {
@@ -43,6 +43,34 @@ function store(overrides = {}) {
     idGenerator: () => 'test-id',
     ...overrides,
   });
+}
+
+// The symlink fixtures below live at a fixed path inside the checkout, so a failed
+// security assertion can also mean the fixture was disturbed mid-test. Checking the
+// fixture separately keeps a real regression apart from interference (see issue #25).
+async function describeTree(path) {
+  try {
+    return (await readdir(path)).join(', ') || '<empty>';
+  } catch (error) {
+    return `<${error.code}>`;
+  }
+}
+
+async function assertSymlinkFixture(path, description) {
+  let stats;
+  try {
+    stats = await lstat(path);
+  } catch (error) {
+    assert.fail(
+      `fixture missing: ${description} (${error.code}); `
+        + `${artifactRoot} contains: ${await describeTree(artifactRoot)}`,
+    );
+  }
+  assert.ok(
+    stats.isSymbolicLink(),
+    `fixture broken: ${description} is not a symlink; `
+      + `${artifactRoot} contains: ${await describeTree(artifactRoot)}`,
+  );
 }
 
 function statePath(scope, namespace, key) {
@@ -181,25 +209,29 @@ test('rejects symlink state roots and symlink ancestors while allowing valid non
   const outside = resolve(artifactRoot, 'outside');
   await mkdir(outside, { recursive: true });
   await symlink(outside, roots.workstreamStateRoot);
+  await assertSymlinkFixture(roots.workstreamStateRoot, 'workstream root symlink');
   await assert.rejects(
     store().health(),
     (error) => error.code === 'PATH_TRAVERSAL',
+    'a symlinked state root must be rejected',
   );
 
   await rm(artifactRoot, { recursive: true, force: true });
   await mkdir(resolve(artifactRoot, 'real-parent'), { recursive: true });
   await symlink(resolve(artifactRoot, 'real-parent'), resolve(artifactRoot, 'linked-parent'));
+  await assertSymlinkFixture(resolve(artifactRoot, 'linked-parent'), 'ancestor symlink');
   await assert.rejects(
     store({
       projectStateRoot: resolve(artifactRoot, 'linked-parent/project'),
       workstreamStateRoot: resolve(artifactRoot, 'linked-parent/workstream'),
     }).health(),
     (error) => error.code === 'PATH_TRAVERSAL',
+    'a symlinked ancestor must be rejected',
   );
 
   await rm(artifactRoot, { recursive: true, force: true });
   const state = store();
-  assert.equal((await state.health()).ok, true);
+  assert.equal((await state.health()).ok, true, 'a nonexistent root must be created on demand');
 });
 
 test('fails closed when a validated descendant is swapped for an escaping symlink', async () => {


### PR DESCRIPTION
## What

Adds failure diagnostics to the intermittently failing symlink test in `test/unit/state-store.test.mjs`. No behaviour under test changes.

- Each of the three assertions in the test now carries its own message, so a failure says *which* expectation broke.
- The symlink fixtures are verified (`lstat` → `isSymbolicLink()`) before the security assertion runs.
- When a fixture is missing or is no longer a symlink, the failure reports the contents of `test/.artifacts/state-store`.

## Why

Issue #25 reports this test failing roughly 1 in 7 full-suite runs, and explicitly asks for the failing assertion plus the state of the artifact root to be captured **before** any fix is attempted. Previously all three assertions shared one anonymous `assert.rejects` failure, which cannot distinguish a genuine `PATH_TRAVERSAL` regression from the fixture being disturbed mid-test.

This PR is diagnostics only and leaves #25 open — it makes the next occurrence actionable.

## Reproduction attempt

30 consecutive full-suite runs (`node --test`) on macOS / Node 22.22.0 produced **0 failures**. At the reported 1-in-7 rate the chance of that is under 1%, so the failure is either environment-specific or already much rarer on current `main`.

## Verification

- `npm run lint` — passes
- `npm run check` — passes
- `node --test test/unit/state-store.test.mjs` — 24/24 pass
- Diagnostic path exercised with a deliberately disturbed fixture; it reports:
  `fixture missing: workstream root symlink (ENOENT); .../test/.artifacts/state-store contains: <ENOENT>`

Refs #25