### PR TITLE
ci: publish releases to npm with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,59 @@ jobs:
             gh release create "$TAG" "$TARBALL" \
               --title "$TITLE" --notes-file release-notes.md "${flags[@]}"
           fi
+
+  publish-npm:
+    name: Publish to npm
+    needs: [verify, publish]
+    # npm accepts a trusted publisher only for a package that already exists, so
+    # this job stays dormant until the one-time bootstrap described in
+    # CONTRIBUTING.md is done and the repository variable NPM_PUBLISH is set to
+    # "enabled". A published version cannot be taken back, so it runs only after
+    # the GitHub release succeeded.
+    if: vars.NPM_PUBLISH == 'enabled'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Mints the OIDC token that authenticates the publish and signs provenance.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.verify.outputs.tag }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      - name: Use an npm release that supports trusted publishing
+        run: npm install --global npm@^11.5.1
+
+      - name: Publish the tagged version
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          published="$(npm view "agent-trestle@$VERSION" version 2>/dev/null || true)"
+          if [ -n "$published" ]; then
+            echo "agent-trestle@$VERSION is already on the registry; nothing to publish."
+            exit 0
+          fi
+          dist_tag=latest
+          case "$VERSION" in *-*) dist_tag=next ;; esac
+          npm publish --access public --tag "$dist_tag"
+
+      - name: Verify the version resolves from the registry
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          for _ in 1 2 3 4 5; do
+            if [ "$(npm view "agent-trestle@$VERSION" version 2>/dev/null || true)" = "$VERSION" ]; then
+              echo "agent-trestle@$VERSION resolves from the registry."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "agent-trestle@$VERSION did not resolve from the registry." >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+### Added
+
+- npm publishing in the release workflow, using npm trusted publishing (OIDC),
+  so no registry token is stored in the repository and every published version
+  carries a provenance attestation. Pre-release versions go to the `next`
+  dist-tag, everything else to `latest`, and re-running a release for an
+  already published version is a no-op. The job stays dormant until the
+  repository variable `NPM_PUBLISH` is set to `enabled`; `CONTRIBUTING.md`
+  documents the one-time bootstrap that npm requires before a trusted publisher
+  can be configured.
+
+### Fixed
+
+- The name-clearance release gate claimed that the npm name had been reserved by
+  publishing `0.1.0`. No version was ever published; the registry entry did not
+  exist. The gate now records the name as unreserved, matching the availability
+  table in the same document.
+
 ## [0.2.0] — 2026-08-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,43 @@ artifact is published. Versions below `1.0.0` and any tag with a pre-release
 suffix are marked as pre-releases. Existing tags can be re-published through
 the workflow's manual dispatch input.
 
+### Publishing to npm
+
+The release workflow also publishes to the npm registry, using
+[trusted publishing](https://docs.npmjs.com/trusted-publishers): GitHub mints a
+short-lived OIDC token for the workflow, so no npm token is stored in this
+repository, and npm attaches a provenance attestation to every published
+version. Pre-release versions go to the `next` dist-tag, everything else to
+`latest`. Re-running a release for an already published version is a no-op.
+
+That job only runs when the repository variable `NPM_PUBLISH` is set to
+`enabled`, because npm accepts a trusted publisher only for a package that
+already exists. Claiming the name therefore takes a documented one-time
+bootstrap:
+
+1. Confirm the name decision first. Distributing a package under this name is
+   the step that carries trademark exposure, and the gate in
+   [name clearance](docs/name-clearance.md) is not fully satisfied.
+2. Download the tarball from the newest GitHub release rather than packing
+   locally, so the first published bytes are the ones CI built and smoke-tested:
+   `gh release download vX.Y.Z --pattern '*.tgz'`.
+3. `npm login`, then `npm publish agent-trestle-X.Y.Z.tgz --access public`.
+   This first version carries no provenance; npm cannot attach one to a
+   pre-packed tarball.
+4. On npmjs.com, open the package settings and add a trusted publisher:
+   organization/user `trsdn`, repository `agent-trestle`, workflow filename
+   `release.yml`, environment empty. If you set an environment there, the
+   `publish-npm` job must declare the same one.
+5. Under *Publishing access*, select *Require two-factor authentication and
+   disallow tokens*, so the OIDC workflow becomes the only publishing path.
+6. Set the repository variable: `gh variable set NPM_PUBLISH --body enabled`.
+7. Update the install section of [`README.md`](README.md) and the registry row
+   in [name clearance](docs/name-clearance.md), both of which state that the
+   package is unpublished.
+
+From the next tag onwards, publishing is fully automated and no longer touches
+a maintainer's credentials.
+
 ## Documentation
 
 Documentation lives in [`docs/`](docs). Prose wraps at 80 columns, matching

--- a/docs/name-clearance.md
+++ b/docs/name-clearance.md
@@ -52,12 +52,12 @@ The gate below separates two decisions that were previously conflated:
 publishing the source, and distributing a package under the name. Trademark
 exposure attaches mainly to the second.
 
-| # | Condition | Status at 2026-08-20 |
+| # | Condition | Status at 2026-08-24 |
 |---|---|---|
-| 1 | reserve the GitHub and npm `agent-trestle` identifiers | GitHub reserved; npm reserved by publishing `0.1.0` |
+| 1 | reserve the GitHub and npm `agent-trestle` identifiers | GitHub reserved; npm **not** reserved, the name was still unclaimed on 2026-08-24 |
 | 2 | authoritative USPTO/EUIPO and national-register search | **not performed** |
 | 3 | likelihood-of-confusion assessment where required | **not performed** |
-| 4 | recheck exact-name registry availability | done 2026-08-20, see the table above |
+| 4 | recheck exact-name registry availability | done 2026-08-20; npm rechecked 2026-08-24 |
 | 5 | confirm the independent source-provenance gate | see [provenance audit](provenance-audit.md); covers the baseline only |
 
 Conditions 2 and 3 require qualified counsel and remain outstanding. The

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "./worktrees": "./src/worktrees/index.mjs",
     "./schemas/config.json": "./schemas/config.schema.json"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "src/",
     "schemas/",


### PR DESCRIPTION
## What

Adds an npm publishing job to the release workflow and documents the one-time bootstrap npm requires before it can be switched on.

- `publish-npm` job in `.github/workflows/release.yml`, gated on the repository variable `NPM_PUBLISH == 'enabled'`.
- Authentication via [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC, `id-token: write`) — no registry token is stored in this repository, and npm attaches a provenance attestation automatically.
- `publishConfig.access = "public"` in the manifest.
- `CONTRIBUTING.md` gains a "Publishing to npm" section with the bootstrap checklist.
- Corrects a false claim in `docs/name-clearance.md` (see below).

## Design notes

- **Runs after the GitHub release, not in parallel.** An npm version cannot be withdrawn after the unpublish window, so the irreversible step goes last.
- **Idempotent.** A version already on the registry is skipped, which keeps the manual `workflow_dispatch` replay path working.
- **Dist-tags.** Versions with a pre-release suffix publish to `next`; everything else to `latest`. `0.x` stays on `latest`, which is the npm convention for pre-1.0 packages.
- **npm CLI upgrade.** Trusted publishing needs npm ≥ 11.5.1; Node 22 ships npm 10.x, so the job installs a supporting npm release first.
- **Publishes from a source checkout, not the packed tarball.** npm cannot attach provenance to a pre-packed tarball, so the job checks out the tag and lets npm pack.
- **Dormant by default.** npm only accepts a trusted publisher for a package that already exists, so enabling this before the bootstrap would fail every release. The variable gate keeps the workflow green until the name is claimed.

## Name-clearance correction

The release gate in `docs/name-clearance.md` recorded `npm reserved by publishing 0.1.0`. No version was ever published — `registry.npmjs.org/agent-trestle` returns 404 — and the claim contradicted the availability table in the same document, which lists the name as unregistered at both checks. The gate now records the name as unreserved.

Worth flagging before anyone sets `NPM_PUBLISH=enabled`: that same document states that trademark exposure attaches mainly to distributing a package under the name, and that gate conditions 2 and 3 (register search, likelihood-of-confusion assessment) remain unsatisfied. This PR only builds the mechanism; it does not claim the name.

## Verification

- `npm run lint` — passes
- `npm run check` — 243 tests, 0 failures
- Workflow parses; job wiring confirmed (`needs: [verify, publish]`, `if: vars.NPM_PUBLISH == 'enabled'`, `permissions: {contents: read, id-token: write}`)
- The skip and dist-tag shell logic was exercised against the live registry across four cases: unpublished package, existing package + version (skips), existing package + missing version (publishes), pre-release version (selects `next`)