### PR TITLE
docs: record the completed npm publish bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,7 @@ jobs:
         run: npm install --global npm@^11.5.1
 
       - name: Publish the tagged version
+        id: publish
         env:
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
@@ -164,11 +165,13 @@ jobs:
           published="$(npm view "agent-trestle@$VERSION" version 2>/dev/null || true)"
           if [ -n "$published" ]; then
             echo "agent-trestle@$VERSION is already on the registry; nothing to publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           dist_tag=latest
           case "$VERSION" in *-*) dist_tag=next ;; esac
           npm publish --access public --tag "$dist_tag"
+          echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Verify the version resolves from the registry
         env:
@@ -184,3 +187,26 @@ jobs:
           done
           echo "agent-trestle@$VERSION did not resolve from the registry." >&2
           exit 1
+
+      - name: Confirm the publish was tokenless
+        # This repository stores no npm credential and never passes
+        # --provenance, so a provenance attestation can only have come from
+        # trusted publishing. Its absence means the trusted publisher on
+        # npmjs.com is missing or does not match this workflow, and the release
+        # must fail loudly rather than leave an unattested version behind.
+        if: steps.publish.outputs.published == 'true'
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          attestation=""
+          for _ in 1 2 3 4 5; do
+            attestation="$(npm view "agent-trestle@$VERSION" dist.attestations.url 2>/dev/null || true)"
+            [ -n "$attestation" ] && break
+            sleep 10
+          done
+          if [ -z "$attestation" ]; then
+            echo "::error::agent-trestle@$VERSION carries no provenance attestation, so it was not published through trusted publishing. Register the trusted publisher for this package on npmjs.com; see the 'Publishing to npm' section of CONTRIBUTING.md."
+            exit 1
+          fi
+          echo "Provenance attestation: $attestation"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,27 +144,32 @@ version. Pre-release versions go to the `next` dist-tag, everything else to
 
 That job only runs when the repository variable `NPM_PUBLISH` is set to
 `enabled`, because npm accepts a trusted publisher only for a package that
-already exists. Claiming the name therefore takes a documented one-time
-bootstrap:
+already exists. The name was claimed on 2026-08-24 by publishing
+`agent-trestle@0.2.0` from a maintainer account, and `NPM_PUBLISH` has been
+`enabled` ever since. That bootstrap is done and does not need repeating unless
+the package is renamed, in which case:
 
-1. Confirm the name decision first. Distributing a package under this name is
-   the step that carries trademark exposure, and the gate in
+1. Confirm the name decision first. Distributing a package under a name is the
+   step that carries trademark exposure, and the gate in
    [name clearance](docs/name-clearance.md) is not fully satisfied.
 2. Download the tarball from the newest GitHub release rather than packing
    locally, so the first published bytes are the ones CI built and smoke-tested:
    `gh release download vX.Y.Z --pattern '*.tgz'`.
-3. Authenticate against npmjs.com. Two details bite here. A machine whose
-   `~/.npmrc` sets a `registry` other than npmjs.org authenticates against that
-   host instead, so point npm at a scratch config first:
+3. Authenticate against npmjs.com. A machine whose `~/.npmrc` sets a `registry`
+   other than npmjs.org authenticates against that host instead, so point npm at
+   a scratch config first:
    `printf 'registry=https://registry.npmjs.org/\n' > /tmp/npmrc-bootstrap` and
    export `NPM_CONFIG_USERCONFIG=/tmp/npmrc-bootstrap` for every command below.
-   And the account has two-factor authentication, so this step needs an
-   authenticator code and cannot be automated. If `npm login` opens a browser
-   that returns to your profile page without confirming the CLI session, create
-   a granular access token on npmjs.com instead — *Profile menu → Access
-   Tokens → Generate New Token*, read and write, all packages — and append
-   `//registry.npmjs.org/:_authToken=<token>` to the scratch config. Confirm
-   with `npm whoami` before continuing.
+   Use `npm login --auth-type=legacy`, which prompts for the authenticator code
+   in the terminal. Do not use the default `--auth-type=web` while already
+   signed in to npmjs.com in the browser: npm sends you to
+   `/login?next=/login/cli/<uuid>`, the site drops the `next` parameter for an
+   authenticated session, and `/login/cli/<uuid>` then answers `Unauthorized`
+   while the CLI polls forever. A granular access token with *read and write*
+   on *all packages* works too, appended as
+   `//registry.npmjs.org/:_authToken=<token>`; because the account enforces 2FA
+   for publishing, such a token must have *Bypass 2FA* set. Confirm with
+   `npm whoami` before continuing.
 4. `npm publish agent-trestle-X.Y.Z.tgz --access public`. This first version
    carries no provenance; npm cannot attach one to a pre-packed tarball.
 5. On npmjs.com, open the package settings and add a trusted publisher:
@@ -176,8 +181,7 @@ bootstrap:
    Revoke the bootstrap token and delete the scratch config now.
 7. Set the repository variable: `gh variable set NPM_PUBLISH --body enabled`.
 8. Update the install section of [`README.md`](README.md) and the registry row
-   in [name clearance](docs/name-clearance.md), both of which state that the
-   package is unpublished.
+   in [name clearance](docs/name-clearance.md).
 
 From the next tag onwards, publishing is fully automated and no longer touches
 a maintainer's credentials.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,17 +153,29 @@ bootstrap:
 2. Download the tarball from the newest GitHub release rather than packing
    locally, so the first published bytes are the ones CI built and smoke-tested:
    `gh release download vX.Y.Z --pattern '*.tgz'`.
-3. `npm login`, then `npm publish agent-trestle-X.Y.Z.tgz --access public`.
-   This first version carries no provenance; npm cannot attach one to a
-   pre-packed tarball.
-4. On npmjs.com, open the package settings and add a trusted publisher:
+3. Authenticate against npmjs.com. Two details bite here. A machine whose
+   `~/.npmrc` sets a `registry` other than npmjs.org authenticates against that
+   host instead, so point npm at a scratch config first:
+   `printf 'registry=https://registry.npmjs.org/\n' > /tmp/npmrc-bootstrap` and
+   export `NPM_CONFIG_USERCONFIG=/tmp/npmrc-bootstrap` for every command below.
+   And the account has two-factor authentication, so this step needs an
+   authenticator code and cannot be automated. If `npm login` opens a browser
+   that returns to your profile page without confirming the CLI session, create
+   a granular access token on npmjs.com instead — *Profile menu → Access
+   Tokens → Generate New Token*, read and write, all packages — and append
+   `//registry.npmjs.org/:_authToken=<token>` to the scratch config. Confirm
+   with `npm whoami` before continuing.
+4. `npm publish agent-trestle-X.Y.Z.tgz --access public`. This first version
+   carries no provenance; npm cannot attach one to a pre-packed tarball.
+5. On npmjs.com, open the package settings and add a trusted publisher:
    organization/user `trsdn`, repository `agent-trestle`, workflow filename
    `release.yml`, environment empty. If you set an environment there, the
    `publish-npm` job must declare the same one.
-5. Under *Publishing access*, select *Require two-factor authentication and
+6. Under *Publishing access*, select *Require two-factor authentication and
    disallow tokens*, so the OIDC workflow becomes the only publishing path.
-6. Set the repository variable: `gh variable set NPM_PUBLISH --body enabled`.
-7. Update the install section of [`README.md`](README.md) and the registry row
+   Revoke the bootstrap token and delete the scratch config now.
+7. Set the repository variable: `gh variable set NPM_PUBLISH --body enabled`.
+8. Update the install section of [`README.md`](README.md) and the registry row
    in [name clearance](docs/name-clearance.md), both of which state that the
    package is unpublished.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ problems that a prompt cannot solve:
 
 ## Install
 
-The package is not yet published to npm. Install it from a local clone:
+```bash
+npm install -g agent-trestle
+```
+
+The executable is intentionally named only `agent-trestle`, never `trestle`, to
+avoid colliding with existing npm packages that already install a `trestle`
+binary.
+
+To work on agent-trestle itself, install it from a local clone:
 
 ```bash
 git clone https://github.com/trsdn/agent-trestle.git
@@ -55,12 +63,8 @@ cd agent-trestle
 npm link          # exposes the `agent-trestle` binary
 ```
 
-The executable is intentionally named only `agent-trestle`, never `trestle`, to
-avoid colliding with existing npm packages that already install a `trestle`
-binary.
-
 Tagged releases also attach a packed tarball, so a release can be installed
-without a clone:
+without npm or a clone:
 
 ```bash
 npm install -g https://github.com/trsdn/agent-trestle/releases/download/vX.Y.Z/agent-trestle-X.Y.Z.tgz

--- a/docs/name-clearance.md
+++ b/docs/name-clearance.md
@@ -54,7 +54,7 @@ exposure attaches mainly to the second.
 
 | # | Condition | Status at 2026-08-24 |
 |---|---|---|
-| 1 | reserve the GitHub and npm `agent-trestle` identifiers | GitHub reserved; npm **not** reserved, the name was still unclaimed on 2026-08-24 |
+| 1 | reserve the GitHub and npm `agent-trestle` identifiers | GitHub reserved; npm reserved on 2026-08-24 by publishing `agent-trestle@0.2.0` |
 | 2 | authoritative USPTO/EUIPO and national-register search | **not performed** |
 | 3 | likelihood-of-confusion assessment where required | **not performed** |
 | 4 | recheck exact-name registry availability | done 2026-08-20; npm rechecked 2026-08-24 |


### PR DESCRIPTION
`agent-trestle@0.2.0` is published on npm and the automated publishing path is
live. This PR makes the documentation match that state, and adds a guard so a
misconfigured trusted publisher cannot pass unnoticed.

## What changed outside this diff

- `agent-trestle@0.2.0` published from the CI-built release tarball, so the
  first published bytes are the ones that were built and smoke-tested.
  Verified with a clean install: `npx agent-trestle --version` reports `0.2.0`.
- Repository variable `NPM_PUBLISH` set to `enabled`.
- `release.yml` dispatched for `v0.2.0` end to end. All three jobs succeeded;
  `Publish to npm` took the "already on the registry" path and still verified
  that the version resolves.

## Documentation

- **README** — `npm install -g agent-trestle` is now the primary install. The
  clone route is kept for working on agent-trestle itself, the tarball route
  for installing without npm.
- **name-clearance** — the registry row records the npm identifier as reserved.
  The outstanding trademark conditions (2 and 3) are deliberately untouched.
- **CONTRIBUTING** — the bootstrap is marked done and retained for a future
  rename, with one correction that cost real time: `npm login --auth-type=web`
  cannot complete while the browser is already signed in to npmjs.com. npm
  prints `/login?next=/login/cli/<uuid>`, the site drops the `next` parameter
  for an authenticated session, and `/login/cli/<uuid>` answers `Unauthorized`
  while the CLI polls indefinitely. `--auth-type=legacy` prompts for the
  authenticator code in the terminal and works.

## Release guard

`publish-npm` authenticates through OIDC trusted publishing, but that
configuration lives on npmjs.com and npm exposes no API to read it back. A
trusted publisher that is missing, or whose repository/workflow/environment
claims do not match, is therefore invisible from this repository — the release
would simply produce an unattested version.

This repository stores no npm credential and never passes `--provenance`, so a
provenance attestation can only originate from trusted publishing. The job now
asserts that the version it just published carries one, and fails with a
message pointing at `CONTRIBUTING.md` when it does not.

The assertion is gated on a new `published` step output, so re-running a
release for a version that already exists stays a no-op. That matters for
`0.2.0`, which was published by hand during the bootstrap and carries no
attestation.

Verified against the registry before committing: `dist.attestations.url`
resolves for `sigstore@5.0.0` and is empty for `agent-trestle@0.2.0`, and the
guard exits non-zero on the empty case.

## Still outstanding

The trusted publisher registration on npmjs.com is a manual, browser-only step.
Until the next unpublished version ships, the OIDC path stays configured but
unexercised — at which point the guard above turns a silent misconfiguration
into a failed release. `docs/name-clearance.md` conditions 2 and 3 remain
unsatisfied.
