### PR TITLE
chore(release): 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-08-24
+
+This release ships no code changes. It is the first version published to npm
+through the automated pipeline, so unlike `0.2.0` it carries a provenance
+attestation that ties the published artifact to the workflow run that built it.
+
 ### Added
 
 - npm publishing in the release workflow, using npm trusted publishing (OIDC),
@@ -17,16 +23,24 @@ are not yet stable and may change without a major version bump.
   carries a provenance attestation. Pre-release versions go to the `next`
   dist-tag, everything else to `latest`, and re-running a release for an
   already published version is a no-op. The job stays dormant until the
-  repository variable `NPM_PUBLISH` is set to `enabled`; `CONTRIBUTING.md`
-  documents the one-time bootstrap that npm requires before a trusted publisher
-  can be configured.
+  repository variable `NPM_PUBLISH` is set to `enabled`.
+- A release check that fails the run when a version it just published carries
+  no provenance attestation. Trusted publisher configuration lives on npmjs.com
+  and npm exposes no API to read it back, so a missing or mismatched publisher
+  would otherwise degrade silently into an unattested release.
+
+### Changed
+
+- `agent-trestle` installs from npm: `npm install -g agent-trestle`. The clone
+  route is retained for working on Agent Trestle itself and the release tarball
+  for installing without a registry.
 
 ### Fixed
 
-- The name-clearance release gate claimed that the npm name had been reserved by
-  publishing `0.1.0`. No version was ever published; the registry entry did not
-  exist. The gate now records the name as unreserved, matching the availability
-  table in the same document.
+- The name-clearance release gate claimed that the npm name had been reserved
+  by publishing `0.1.0`. No version was ever published at that point. The gate
+  now records the reservation that `0.2.0` actually made, matching the
+  availability table in the same document.
 
 ## [0.2.0] — 2026-08-24
 
@@ -102,5 +116,7 @@ are not yet stable and may change without a major version bump.
 - Least-privilege permission defaults, with unrestricted tools, paths, URLs,
   non-interactive execution, and auto-merge all opt-in.
 
-[Unreleased]: https://github.com/trsdn/agent-trestle/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/trsdn/agent-trestle/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/trsdn/agent-trestle/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/trsdn/agent-trestle/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/trsdn/agent-trestle/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-trestle",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Local-first orchestration for GitHub Copilot CLI agents.",
   "type": "module",
   "author": "trsdn",


### PR DESCRIPTION
Cuts `0.2.1`. The release ships no code changes; its purpose is to exercise the
npm trusted publishing path end to end.

`0.2.0` was published by hand, because npm accepts a trusted publisher only for
a package that already exists. That bootstrap version therefore carries no
provenance. The trusted publisher is now registered for this package
(`trsdn/agent-trestle`, workflow `release.yml`, no environment, `npm publish`
only), so `0.2.1` is the first version that will be minted through OIDC, and
the first whose artifact can be traced back to the workflow run that built it.

If the trusted publisher were missing or mismatched, the release would publish
an unattested version and the provenance check merged in #31 would fail the
run — which is exactly the signal this release is meant to produce.

## Changes

- `CHANGELOG.md` — the `Unreleased` entries move under `## [0.2.1]`, with the
  npm-publishing and provenance-guard additions, the install-source change, and
  the name-clearance correction restated as the net delta from `0.2.0`.
- `package.json` — version `0.2.1`.
- `CHANGELOG.md` comparison links repaired. They were never updated when
  `0.2.0` shipped: `Unreleased` still compared against `v0.1.0` and no link
  definition existed for `0.2.0`.

## Verification

- `node scripts/release.mjs verify --tag v0.2.1` — tag, manifest, and changelog
  section agree.
- `node scripts/release.mjs notes --tag v0.2.1` renders the intended notes.
- `npm run lint` passes.

## After merge

Tag the merge commit `v0.2.1` and push it. The workflow verifies, tests, packs,
smoke-tests a clean install, publishes the GitHub release, publishes to npm
through OIDC, and asserts the published version carries a provenance
attestation.
