### PR TITLE
fix(state): settle every root pin before a failed initialisation rejects

### DIFF
--- a/src/state/store.mjs
+++ b/src/state/store.mjs
@@ -3,7 +3,7 @@ import { constants } from 'node:fs';
 import { lstat, mkdir, open, readdir, rename, rm } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
-import { pinDirectory, verifyDescendant, verifyPinnedDirectory } from '../security/path-security.mjs';
+import { pinDirectory, releasePin, verifyDescendant, verifyPinnedDirectory } from '../security/path-security.mjs';
 
 const DEFAULT_VERSION = 1;
 const LOCK_RETRY_MS = 10;
@@ -722,11 +722,25 @@ export class TrestleStateStore {
   async #initializeRoots() {
     if (this.rootPins) return this.rootPins;
     if (!this.rootPinsPromise) {
-      this.rootPinsPromise = Promise.all([
+      // Every pin must settle before this rejects. Promise.all surfaces the
+      // first failure while the remaining pins are still creating their
+      // directories, so a caller that reacts to the rejection by clearing the
+      // state root races those pending mkdirs and sees a spurious ENOTEMPTY.
+      // Settling first also lets the pins that did succeed hand back their
+      // descriptors, which Promise.all leaks on every failed initialisation.
+      this.rootPinsPromise = Promise.allSettled([
         pinDirectory(this.projectStateRoot, { create: true }),
         pinDirectory(this.workstreamStateRoot, { create: true }),
         pinDirectory(this.configRoot, { create: true }),
-      ]).then(([project, workstream, config]) => {
+      ]).then(async (results) => {
+        const failure = results.find((result) => result.status === 'rejected');
+        if (failure) {
+          for (const result of results) {
+            if (result.status === 'fulfilled') await releasePin(result.value);
+          }
+          throw failure.reason;
+        }
+        const [project, workstream, config] = results.map((result) => result.value);
         this.rootPins = { project, workstream, config };
         return this.rootPins;
       });

--- a/test/unit/state-store.test.mjs
+++ b/test/unit/state-store.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { lstat, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
@@ -232,6 +233,37 @@ test('rejects symlink state roots and symlink ancestors while allowing valid non
   await rm(artifactRoot, { recursive: true, force: true });
   const state = store();
   assert.equal((await state.health()).ok, true, 'a nonexistent root must be created on demand');
+});
+
+// A rejected root initialisation used to leave the remaining pins creating their
+// directories in the background. Callers that clear the state root after a failed
+// health() then raced those mkdirs and saw a spurious ENOTEMPTY (issue #25).
+// The sibling roots are nested deliberately: creating them costs many more
+// syscalls than rejecting the shallow symlinked root, so before the fix they
+// could not yet exist at the moment health() rejected.
+test('settles every root pin before a failed initialisation rejects', async () => {
+  const nested = 'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t';
+  const projectStateRoot = resolve(artifactRoot, nested, 'project');
+  const configRoot = resolve(artifactRoot, nested, 'config');
+  const outside = resolve(artifactRoot, 'outside');
+  await mkdir(outside, { recursive: true });
+  await symlink(outside, roots.workstreamStateRoot);
+
+  await assert.rejects(
+    store({ projectStateRoot, configRoot }).health(),
+    (error) => error.code === 'PATH_TRAVERSAL',
+    'a symlinked state root must be rejected',
+  );
+
+  // Synchronous on purpose. Awaiting anything here would hand a still-pending
+  // pin the event-loop turn it needs to land its mkdir, which is exactly the
+  // outstanding work this test exists to rule out.
+  assert.ok(existsSync(projectStateRoot), 'the project pin must settle before health() rejects');
+  assert.ok(existsSync(configRoot), 'the config pin must settle before health() rejects');
+
+  // The cleanup that failed intermittently while that work was still in flight.
+  await rm(artifactRoot, { recursive: true, force: true });
+  assert.equal(existsSync(artifactRoot), false, 'a settled failure must leave a removable tree');
 });
 
 test('fails closed when a validated descendant is swapped for an escaping symlink', async () => {


### PR DESCRIPTION
Fixes #25.

## Root cause

`#initializeRoots` pinned the three state roots with `Promise.all`:

```js
Promise.all([
  pinDirectory(this.projectStateRoot, { create: true }),
  pinDirectory(this.workstreamStateRoot, { create: true }),
  pinDirectory(this.configRoot, { create: true }),
])
```

`Promise.all` rejects as soon as the first pin fails, but it does not stop the
others. Each pin creates its directory, so after a rejected `health()` the
remaining pins were still running `mkdir`. A caller that reacts to the failure
by clearing the state root then raced them: a fresh entry appeared between the
recursive walk and the final `rmdir`, and the removal failed with `ENOTEMPTY`.

The failing test was never wrong about security. The symlinked root was
rejected correctly every time — the test was reporting its own cleanup.

## Evidence

A temporary push-triggered harness ran the full suite 40 times per job across
Linux and macOS on Node 20 and 22. The flake reproduced in **3 of 160 runs**,
on both operating systems, always with the same error:

```
error: "ENOTEMPTY: directory not empty, rmdir '.../test/.artifacts/state-store'"
code: 'ENOTEMPTY'
```

A second harness run instrumented the cleanup to name the blocking entry:

```
cleanup failed at symlink-test/after-ancestor-symlink: ENOTEMPTY after 1ms;
now=1787604246833; contains: config[dir mtime=1787604246832.9 nlink=2]
```

`config` was created 0.1 ms before the failure — during the removal — by the
pin that outlived the rejection. A second occurrence showed `project` with the
same 0.3 ms signature. That is the mechanism, not an inference.

This also explains why the flake never reproduced locally: 30 full-suite runs
on an idle workstation, and 300 targeted runs even under ten-way CPU load, all
passed. The window only opens when the runner is slow enough for the mkdir to
land after the rejection.

## The fix

Pins are settled before the failure is rethrown, and the pins that did succeed
are released instead of dropped — `Promise.all` leaked an open directory
descriptor for every root that succeeded alongside a failure.

One deliberate behavioural change: the reported error is now the first by root
order rather than the first by completion, which makes a multi-root failure
deterministic.

## Regression test

The new test nests the sibling roots so that creating them costs many more
syscalls than rejecting the shallow symlinked root. Before the fix they cannot
yet exist at the moment `health()` rejects, so the test fails reliably instead
of reproducing the original ~2% flake:

```
--- WITHOUT fix ---
not ok 8 - settles every root pin before a failed initialisation rejects
  error: 'the project pin must settle before health() rejects'
--- WITH fix ---
# pass 25  # fail 0
```

The assertions after the rejection are synchronous on purpose: awaiting
anything there would hand a pending pin the event-loop turn it needs to land
its `mkdir`, masking the very condition under test.

## Verification

- `npm run lint`, `npm test`, and `npm run test:coverage` all pass.
- The repro harness was re-run with this fix applied; results are reported in
  the issue.

## Out of scope

The harness surfaced three unrelated flaky tests, which are not touched here
and are reported separately on #25:

- `spawn adapter escalates to SIGKILL when a timed-out process ignores SIGTERM`
- `supervisor falls back to direct children without process-group support`
- `serializes concurrent appends without losing entries` (`LOCK_STALE`)
