### PR TITLE
docs: record the state-root initialisation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- A failed state-root initialisation no longer leaves directory creation running
+  in the background. `health()` pinned the project, workstream, and config roots
+  with `Promise.all`, which rejects on the first failure without stopping the
+  others, so a caller that cleared its state root after a rejection raced the
+  pins that were still creating their directories and saw a spurious
+  `ENOTEMPTY`. Pins now settle before the failure is rethrown, and the pins that
+  did succeed are released instead of dropped, which also closes a directory
+  descriptor that leaked on every failed initialisation.
+
 ## [0.2.1] — 2026-08-24
 
 This release ships no code changes. It is the first version published to npm


### PR DESCRIPTION
Adds the `Unreleased` changelog entry for the fix merged in #33.

The fix changes observable behaviour for anyone calling `health()`: a rejected
initialisation no longer leaves `mkdir` calls running behind it, and it no
longer leaks a directory descriptor per root that succeeded alongside the
failure. That belongs in the changelog rather than only in the commit history.