### PR TITLE
test: wait for observable state instead of fixed durations

### DIFF
--- a/test/unit/copilot-process-adapter.test.mjs
+++ b/test/unit/copilot-process-adapter.test.mjs
@@ -73,6 +73,12 @@ test("spawn adapter reports timeout and the actual termination signal", async ()
   assert.equal(result.signal, "SIGTERM");
 });
 
+// The timeout has to outlast the child's interpreter startup, or SIGTERM
+// arrives before the handler below is installed, the default disposition
+// terminates the process, and the escalation under test never happens.
+// Startup was measured at 18 ms median and 35 ms worst case on an idle
+// machine, and is unbounded on a loaded CI runner; the process-tree test in
+// this file has used 700 ms without flaking, so match it.
 test("spawn adapter escalates to SIGKILL when a timed-out process ignores SIGTERM", async () => {
   const startedAt = Date.now();
   const result = await spawnProcess(
@@ -81,13 +87,15 @@ test("spawn adapter escalates to SIGKILL when a timed-out process ignores SIGTER
       "-e",
       "process.on('SIGTERM', () => process.stdout.write('term-ignored')); setInterval(() => {}, 1000)",
     ],
-    { timeoutMs: 50, killGraceMs: 50 },
+    { timeoutMs: 700, killGraceMs: 50 },
   );
   assert.equal(result.timedOut, true);
   assert.equal(result.exitCode, null);
   assert.equal(result.signal, "SIGKILL");
   assert.equal(result.stdout, "term-ignored");
-  assert.ok(Date.now() - startedAt < 1_000);
+  // Bounds the escalation, not the runner: the assertion above already proves
+  // SIGKILL followed SIGTERM, so this only has to exclude an unbounded wait.
+  assert.ok(Date.now() - startedAt < 5_000);
 });
 
 test(

--- a/test/unit/live-child-supervisor.test.mjs
+++ b/test/unit/live-child-supervisor.test.mjs
@@ -106,7 +106,10 @@ test("supervisor falls back to direct children without process-group support", a
   supervisor.register(child, { detached: false });
 
   processImpl.emit("SIGTERM");
-  await sleep(20);
+  // Waits for the escalation itself rather than for a fixed duration: the
+  // grace and settlement timers are 5 ms each, but a loaded runner fires them
+  // late, and a fixed sleep then asserts against an unfinished sequence.
+  await waitFor(() => child.kills.length === 2 && reRaised.length === 1);
   assert.deepEqual(processImpl.kills, []);
   assert.deepEqual(child.kills, ["SIGTERM", "SIGKILL"]);
   assert.deepEqual(reRaised, ["SIGTERM"]);
@@ -124,7 +127,7 @@ test("supervisor never signals the caller's own process group", async () => {
   supervisor.register(child, { detached: true });
 
   processImpl.emit("SIGHUP");
-  await sleep(20);
+  await waitFor(() => child.kills.length === 2);
   assert.deepEqual(processImpl.kills, []);
   assert.deepEqual(child.kills, ["SIGTERM", "SIGKILL"]);
 });
@@ -146,12 +149,18 @@ test("supervisor leaves an existing library-consumer signal policy in control", 
   const registration = supervisor.register(fakeChild(501), { detached: true });
 
   processImpl.emit("SIGTERM");
-  await sleep(20);
+  // The escalation is observable through the recorded kills; waiting on it
+  // instead of on a duration keeps the assertions below on the far side of the
+  // sequence even when a loaded runner fires the grace timer late.
+  await waitFor(() => processImpl.kills.length === 2);
   assert.equal(externalSignals, 1);
   assert.deepEqual(reRaised, []);
   assert.equal(processImpl.listenerCount("SIGTERM"), 2);
 
   registration.unregister();
-  assert.equal(processImpl.listenerCount("SIGTERM"), 1);
+  // Settlement may still be pending here, and it is settlement that uninstalls
+  // the supervisor's handler, so converge on the end state rather than
+  // assuming it has already been reached.
+  await waitFor(() => processImpl.listenerCount("SIGTERM") === 1);
   processImpl.removeListener("SIGTERM", externalHandler);
 });


### PR DESCRIPTION
Refs #35. Fixes the two flakes that were observed on CI, plus a third with the
same defect that stress testing exposed before it could reach a runner.

All three asserted against a sequence that had not necessarily finished.

## `spawn adapter escalates to SIGKILL when a timed-out process ignores SIGTERM`

The test gave the child 50 ms before firing the timeout. The child is a Node
process, and it can only ignore SIGTERM once the interpreter has booted far
enough to run `process.on('SIGTERM', ...)`. Measured on an idle machine:

| | median | p95 | max |
|---|---:|---:|---:|
| `node -e` to first output | 18.4 ms | 27.4 ms | 35.0 ms |

Against a 50 ms budget that is not a margin, and on a loaded three-core runner
it is no margin at all. When the timeout wins, the default disposition
terminates the child and the escalation under test never happens.

Reproduced locally under twelve-way CPU load — 1 failure in 40 runs, with
exactly the error seen on CI:

```
expected: 'SIGKILL'
actual:   'SIGTERM'
```

The timeout now matches the 700 ms already used by the process-tree test in the
same file, which has never been reported flaky. **Zero failures in 70 runs**
under the same load. The elapsed-time assertion is relaxed from 1 s to 5 s: the
signal assertion above it already proves SIGKILL followed SIGTERM, so its only
remaining job is to exclude an unbounded wait, not to measure the runner.

## Two supervisor tests

Both waited a fixed 20 ms for a grace-plus-settlement sequence configured at
5 ms + 5 ms, then asserted the end state. A runner that fires those timers late
lands the assertions mid-sequence. They now wait on the state they actually
care about — the recorded kills, and the listener count — using the `waitFor`
helper already present in the file and already used by a sibling test.

`supervisor leaves an existing library-consumer signal policy in control` was
not among the CI failures, but it carries the same defect and was in fact the
first to break under stress: its `listenerCount` assertion runs after
`unregister()`, while it is settlement that uninstalls the supervisor's
handler, so a late timer leaves the handler installed and the count at 2.

Verified by slowing the supervisor's own timers, which models a late-firing
runner directly:

| grace + settlement | before | after |
|---|---|---|
| 5 ms + 5 ms (configured) | 5 pass | 5 pass |
| 15 ms + 15 ms | **2 fail** | 5 pass |
| 60 ms + 60 ms | — | 5 pass |

## The third report in #35

`serializes concurrent appends without losing entries` failed once with
`LOCK_STALE`. That occurrence predates the fix in #33, and it did not recur in
the 160-run verification of that fix. It is plausibly a downstream effect of
the cleanup failure fixed there — a `beforeEach` that throws leaves the
previous test's state in place. It is deliberately **not** patched here on the
strength of a single pre-fix observation. A 240-run harness across both
platforms is running against this branch; if it recurs, it gets its own
investigation rather than a speculative change.

## Verification

`npm run lint`, `npm test`, and `npm run test:coverage` all pass.
