### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+Orientation for coding agents working in this repository. Humans should start
+with [CONTRIBUTING.md](CONTRIBUTING.md) — this file does not replace it and
+deliberately does not restate the review bar, the provenance rules, or the
+security invariants. Where a rule already exists there, this file links to it.
+
+Every command below was executed on this repository before being written down.
+
+## Setup: there is no install step
+
+Agent Trestle has **zero npm dependencies**, runtime or development. There is
+no `node_modules`, and no `package-lock.json`.
+
+Consequences an agent must not get wrong:
+
+- **`npm ci` fails here**, and that is correct, not a broken checkout. It exits
+  non-zero with `The 'npm ci' command can only install with an existing
+  package-lock.json`. Do not "fix" this by generating a lockfile or by adding
+  dependencies.
+- **`npm install` is unnecessary.** Clone and run the commands directly.
+- Adding any dependency is a reviewable decision with its own bar; see
+  [the zero-dependency rule](CONTRIBUTING.md#the-zero-dependency-rule).
+
+Requirements: Node.js ≥ 20 (`.nvmrc` pins 22), Git, Linux or macOS. The
+worktree fleet needs POSIX ownership semantics and fails closed on Windows.
+`npm link` exposes the `agent-trestle` binary locally.
+
+## Commands
+
+All of these were run and passed on Node 22.22.3 / npm 10.9.8.
+
+| Command | What it does | Verified result |
+| --- | --- | --- |
+| `npm run lint` | Syntax, JSON and whitespace checks, no deps | `Lint passed: 87 file(s) checked.` |
+| `npm run lint:fix` | Auto-repairs whitespace problems | — |
+| `npm test` | Full suite (`node --test`) | 244 tests, 242 pass, 2 skipped |
+| `npm run test:unit` | `test/unit/` only | 209 tests, 207 pass, 2 skipped |
+| `npm run test:integration` | `test/integration/` only | 34 tests, 34 pass |
+| `npm run test:coverage` | Full suite plus thresholds; Node 22 | 91.36% lines, 82.85% branches |
+| `npm run check` | `lint` + `test` + `npm pack --dry-run` | exit 0 |
+
+`npm run check` is the gate to run before pushing. There is **no build step**:
+the package ships `src/` as-is, so `npm pack --dry-run` is what stands in for a
+build, and it is already part of `check`.
+
+`test:coverage` measured 91.36% lines, 82.85% branches and 90.49% functions
+against thresholds of 88 / 78 / 86, and needs Node 22 because the built-in
+coverage threshold flags are not available on the Node 20 floor.
+
+The two skipped tests are gated on a real Copilot CLI and stay skipped unless
+`TRESTLE_REAL_COPILOT_SMOKE` / `TRESTLE_REAL_COPILOT_REVIEW_SMOKE` are set.
+Leave them skipped.
+
+### Known flakiness under parallel load
+
+`node --test` runs files concurrently, and a few timing-sensitive tests around
+process-tree termination and scheduler settlement fail intermittently on a
+loaded machine. In five full-suite runs here, two runs each reported one or two
+such failures; the same files passed on every isolated re-run.
+
+If a test fails, re-run it in isolation before assuming you broke it:
+
+```bash
+node --test test/unit/<file>.test.mjs   # isolated re-run
+node --test --test-concurrency=1        # full suite, serially (0 failures)
+```
+
+Do **not** delete, skip, or loosen an assertion to make a flake go away, and do
+not weaken CI to match. If a flake is real and reproducible, it belongs in its
+own issue and its own pull request.
+
+## Architecture in brief
+
+Project-owned configuration is separated from reusable runtime code:
+
+```text
+.trestle project configuration
+  -> deterministic workstream/role routing
+  -> GitHub Copilot CLI process adapter
+  -> bounded scheduler or isolated worktree fleet
+  -> exact-diff review and ownership enforcement
+  -> state and per-run audit segments
+  -> read-only local dashboard
+```
+
+Each stage is a directory under `src/`. `audit`, `config`, `copilot`,
+`dashboard`, `dispatch`, `ownership`, `review`, `scheduler`, `state` and
+`worktrees` are public subpath exports declared in `package.json`; `cli`,
+`process` and `security` are internal. The CLI entry point is
+`src/cli/agent-trestle.mjs`.
+
+The boundaries and the safety invariants that hold across every change are
+specified in [docs/architecture.md](docs/architecture.md) and, for
+contributors, in
+[security invariants](CONTRIBUTING.md#security-invariants). Read them before
+touching dispatch, review, ownership, state or audit: several are the reason
+code is shaped the way it is, in particular that containment failures fail
+**closed** and that process failure can never be reported as task success.
+
+Supporting scripts are dependency-free Node programs:
+
+- `scripts/lint.mjs` — the lint pass (`node --check`, JSON parse, whitespace).
+- `scripts/release.mjs` — `verify --tag vX.Y.Z` asserts that the tag,
+  `package.json` version and `CHANGELOG.md` section agree; `notes --tag vX.Y.Z`
+  emits the changelog section used as release notes.
+
+## Conventions
+
+Follow [CONTRIBUTING.md](CONTRIBUTING.md). The points most often missed by an
+agent:
+
+- **Conventional Commits** for every commit message.
+- **Every behavioural change needs a test.** `test/unit/` must not spawn
+  processes; `test/integration/` exercises the CLI, packaging or Git.
+- **Tests must be self-contained** — build your own fixtures and Git identity,
+  never rely on the developer's global Git config. Scratch state goes under
+  `test/.work/` and `test/.artifacts/`, both gitignored.
+- **Add a `CHANGELOG.md` entry under `Unreleased`.**
+- **Update `docs/` in the same pull request** when the command surface,
+  configuration schema or security model changes. `docs/commands.md`
+  disagreeing with actual CLI behaviour is treated as a bug.
+- **Formatting follows `.editorconfig`**: UTF-8, LF, final newline, two-space
+  indent, no trailing whitespace; 100 columns for `.mjs`/`.js`/`.json` and 80
+  for Markdown prose. `npm run lint:fix` repairs whitespace only.
+- **Keep the change focused.** Unrelated cleanups belong in their own pull
+  request.
+- The config schema is closed (`additionalProperties: false`) on purpose.
+  Unknown configuration must fail explicitly rather than be ignored.
+
+## Releasing and publishing
+
+Do not release by hand and do not run `npm publish` locally.
+[`.github/workflows/release.yml`](.github/workflows/release.yml) is triggered by
+a `v*` tag, verifies tag/manifest/changelog agreement, runs lint and tests,
+packs the tarball, smoke-tests it in a clean consumer, publishes the GitHub
+release with changelog notes, and then publishes to npm through
+[trusted publishing](https://docs.npmjs.com/trusted-publishers) — OIDC, no
+stored registry token. Republishing an existing version is a no-op.
+
+The full procedure, including the one-time npm bootstrap and the `NPM_PUBLISH`
+repository variable, is in
+[Releasing](CONTRIBUTING.md#releasing).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,15 @@ All of these were run and passed on Node 22.22.3 / npm 10.9.8.
 the package ships `src/` as-is, so `npm pack --dry-run` is what stands in for a
 build, and it is already part of `check`.
 
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs the same commands as
+four jobs: `Lint`, `Test` across a matrix of Node 20 and 22 on
+`ubuntu-latest` and `macos-latest`, `Package` (`npm pack --dry-run`), and
+`Coverage`. Windows is excluded on purpose — the worktree fleet requires POSIX
+ownership semantics and fails closed there. Coverage thresholds run only on the
+`.nvmrc` runtime, because the built-in threshold flags need Node 22 while the
+suite itself must still pass on the Node 20 floor. So `npm run check` locally
+plus Node 20 compatibility is what CI will hold you to.
+
 `test:coverage` measured 91.36% lines, 82.85% branches and 90.49% functions
 against thresholds of 88 / 78 / 86, and needs Node 22 because the built-in
 coverage threshold flags are not available on the Node 20 floor.
@@ -132,11 +141,27 @@ agent:
 
 Do not release by hand and do not run `npm publish` locally.
 [`.github/workflows/release.yml`](.github/workflows/release.yml) is triggered by
-a `v*` tag, verifies tag/manifest/changelog agreement, runs lint and tests,
-packs the tarball, smoke-tests it in a clean consumer, publishes the GitHub
-release with changelog notes, and then publishes to npm through
-[trusted publishing](https://docs.npmjs.com/trusted-publishers) — OIDC, no
-stored registry token. Republishing an existing version is a no-op.
+a `v*` tag and runs three jobs in order: `verify` (tag/manifest/changelog
+agreement via `scripts/release.mjs verify`, lint, full suite, `npm pack`, then a
+smoke test that installs the tarball into a clean consumer and asserts the
+installed CLI reports the tagged version), `publish` (the GitHub release, with
+the changelog section as notes and the tarball attached), and `publish-npm`.
+
+`publish-npm` uses npm
+[trusted publishing](https://docs.npmjs.com/trusted-publishers): the job holds
+`id-token: write`, GitHub mints a short-lived OIDC token, and **no npm
+credential is stored in this repository**. Two details are deliberate and must
+not be "tidied up":
+
+- **`--provenance` is never passed.** Trusted publishing attaches provenance on
+  its own. Because the repository holds no registry token, an attestation can
+  only have come from OIDC, so a final step *asserts the published version
+  carries an attestation and fails the release if it does not*. That check is
+  the real guarantee; adding the flag would defeat its purpose by making the
+  attestation prove nothing about how the publish was authenticated.
+- **The job is gated on the repository variable `NPM_PUBLISH`** and queries the
+  registry first, so re-running a release for an already published version is a
+  no-op rather than an error.
 
 The full procedure, including the one-time npm bootstrap and the `NPM_PUBLISH`
 repository variable, is in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+### Added
+
+- `AGENTS.md`, an orientation file for coding agents. It records the verified
+  lint, test and packaging commands, notes that `npm ci` cannot work in a
+  zero-dependency repository with no lockfile, sketches the runtime boundaries,
+  and links to `CONTRIBUTING.md` and `docs/architecture.md` for the conventions
+  and invariants rather than restating them.
+
 ### Fixed
 
 - A failed state-root initialisation no longer leaves directory creation running


### PR DESCRIPTION
## Scope: AGENTS.md only

**The original gap list I was given was wrong — it was a stale-scan artefact.**
The tool that produced it scanned the user's *local* checkout, which was behind
`origin/main`, so work that already exists upstream was reported as missing.

I verified this against a freshly fetched `origin/main` (`a339bbb`) rather than
taking either the scan or the correction on trust:

```
$ git fetch origin --tags
$ git rev-list --count HEAD~1..origin/main
0                       # this branch is based on the origin/main tip
$ git cat-file -e origin/main:AGENTS.md
fatal: path 'AGENTS.md' exists on disk, but not in 'origin/main'
```

| Reported "gap" | Reality on `origin/main` | Action |
| --- | --- | --- |
| `AGENTS.md` missing | ✅ genuinely missing | **added — the only change here** |
| Release workflow missing | ❌ false — `release.yml` exists (`d006fee`, `3de736b`) | none |
| Trusted Publishing missing | ❌ false — already implemented, correctly | none |
| `codeql.yml` exists | ❌ false — it does **not** exist | see below |
| `package.json` = 0.1.0 | ❌ false — it is **0.2.1** | reported, not changed |

**No release workflow was ever created by me, so there was nothing to delete.**
This branch touches **zero workflow files** — verified:

```
$ git diff --name-only origin/main...HEAD | grep -c 'workflows/'
0
```

## Diff is deliberately tiny

The main checkout reportedly has **68 uncommitted files** touching `ci.yml`,
`README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md` and `docs/`. To
keep reconciliation trivial this PR is **2 files, +176, −0**:

| File | Change |
| --- | --- |
| `AGENTS.md` | new file |
| `CHANGELOG.md` | one additive `### Added` block under `Unreleased` |

`CHANGELOG.md` is the only overlap point, and it is a single additive hunk at
the top. **`ci.yml` was not touched.**

## What AGENTS.md documents

Written from `ci.yml`, `release.yml` and `CONTRIBUTING.md`, recording only
commands that were actually executed against this commit:

- **`npm ci` fails here by design.** Zero npm dependencies, no lockfile, so it
  exits non-zero on a healthy checkout. This is the single highest-value fact
  for an agent — without it, the obvious "fix" is to generate a lockfile or add
  dependencies, both of which violate the documented zero-dependency rule.
- **There is no build step;** `npm pack --dry-run` stands in for one and is
  already inside `check`.
- **What CI actually enforces:** `Lint`, `Test` on Node 20 + 22 across
  `ubuntu-latest` and `macos-latest`, `Package`, and `Coverage` — Windows
  excluded on purpose (POSIX ownership, fails closed), coverage thresholds only
  on the `.nvmrc` runtime because they need Node 22 while the suite must still
  pass on the Node 20 floor.
- **The npm trusted-publishing flow and its provenance check** (below).
- Architecture in brief, plus which `src/` directories are public subpath
  exports versus internal (`cli`, `process`, `security`).
- The pre-existing flakiness, and how to distinguish a flake from a real break.

Conventions, security invariants and the release procedure are **linked** to
`CONTRIBUTING.md`, not restated, so the two files cannot drift apart.

## One correction on the provenance detail

The re-scope note said `release.yml` passes `--provenance`. It does not — that
string appears **only inside a comment** explaining that the flag is
deliberately never passed:

```
$ git show origin/main:.github/workflows/release.yml | grep -n -- '--provenance'
193:        # --provenance, so a provenance attestation can only have come from
$ git show origin/main:.github/workflows/release.yml | grep -n 'npm publish'
173:          npm publish --access public --tag "$dist_tag"
```

This makes the existing design *better* than a `--provenance` flag, and
AGENTS.md now records why so a future agent does not "tidy it up": trusted
publishing attaches provenance by itself, and since the repo stores no npm
credential, an attestation can only have come from OIDC. A final step therefore
**asserts the attestation exists and fails the release if it is missing**.
Passing `--provenance` explicitly would let a token-authenticated publish
produce an attestation too, so the check would stop proving anything about
*how* the publish was authenticated. Left exactly as-is.

## Version drift: investigated, not fixed

The brief said `package.json` is `0.1.0`. On `origin/main` it is **not**:

| Source | Version |
| --- | --- |
| `package.json` at `a339bbb` | **0.2.1** |
| Latest git tag | **v0.2.1** |
| npmjs.org `latest` | **0.2.1** |

The project's own authoritative check agrees:

```
$ node scripts/release.mjs verify --tag v0.2.1
agent-trestle 0.2.1 matches v0.2.1 and its CHANGELOG.md section   # exit 0
```

So there is **no drift on `origin/main`** — this too looks like the stale scan
reading the older local checkout. If a `0.1.0` genuinely exists, it can only be
in the uncommitted working tree, which I did not inspect. **`package.json` is
untouched by this PR.** Worth confirming before those 68 files are committed:
committing a reverted version would fail the next release at the `verify` step.

## Commands verified (Node 22.22.3 / npm 10.9.8)

| Command | Result |
| --- | --- |
| `npm ci` | ❌ **fails by design** — no lockfile, zero deps. Documented, not "fixed". |
| `npm run lint` | ✅ `Lint passed: 87 file(s) checked.` |
| `npm test` | ✅ 244 tests, 242 pass, 2 skipped |
| `npm run test:unit` | ✅ 209 tests, 207 pass, 2 skipped |
| `npm run test:integration` | ✅ 34 tests, 34 pass |
| `npm run test:coverage` | ✅ 91.36% lines / 82.85% branches / 90.49% functions vs 88 / 78 / 86 |
| `npm run check` | ✅ **exit 0**, re-run after the final edit |
| `npm pack --dry-run` | ✅ `agent-trestle-0.2.1.tgz`, 69 files |
| `scripts/release.mjs verify` / `notes` | ✅ both exit 0 against `v0.2.1` |

The two skipped tests are environment-gated on a real Copilot CLI.

## Pre-existing condition reported, not patched

The suite is **intermittently flaky under default `node --test` parallelism**,
reproducible on `origin/main` and unrelated to this PR. Two of five full-suite
runs failed:

- `process adapter timeout stops a spawned grandchild writer via process-tree termination`
- `DAG scheduler records all running terminal outcomes before returning a failure`

Both pass on every isolated re-run (3/3), and `node --test
--test-concurrency=1` gives **242 pass / 0 fail** — load-dependent timing, not a
break. Consistent with closed issue #25 and with `a339bbb` *"test: wait for
observable state instead of fixed durations"*. **No test was weakened and no
workflow was loosened to hide it.** A fix belongs in its own PR.

## Deliberately skipped

- **All workflows** — untouched, including `ci.yml` (your uncommitted edits).
- **CodeQL** — the brief claimed `codeql.yml` exists; it does not, and it is
  absent from `gh workflow list` (CI, Release, Dependabot Updates, plus a
  "Flake repro (issue 25)" workflow not on `main`). Out of the revised scope, so
  left alone — flagging as a possible genuine follow-up. Default-setup CodeQL
  may already cover it; that is not visible from the repo.
- **A lockfile** — would contradict the zero-dependency rule.
- **`AGENTS.md` in `package.json` `files`** — omitted, matching how
  `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are already excluded from the
  tarball. This also avoids editing `package.json` at all.
- **Any real `npm publish`** — none performed.

## Security impact

None. Documentation only: no runtime code, no dependency, no workflow
permission and no published artifact changes.
