### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ are not yet stable and may change without a major version bump.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-09-01
+
 ### Added
 
 - Windows is now a supported platform for agent execution, through the sandbox.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-trestle",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Local-first orchestration for GitHub Copilot CLI agents.",
   "type": "module",
   "author": "trsdn",


### PR DESCRIPTION
Bumps the version to 0.3.0 and finalizes the CHANGELOG Unreleased section, ahead of the release workflow. Includes Windows platform support and the opt-in container sandbox (merged in #41).

Once merged, tagging \0.3.0\ on main triggers \.github/workflows/release.yml\ (verify -> GitHub release -> npm publish via trusted publishing).

- \
ode scripts/release.mjs verify --tag v0.3.0\ passes: version and CHANGELOG section agree.
- No code changes, version/changelog only.
